### PR TITLE
Corrected Czech tax calculation

### DIFF
--- a/r-scripts/taxes/Czech-tax.R
+++ b/r-scripts/taxes/Czech-tax.R
@@ -4,23 +4,28 @@
 ############
 # provided by Adam Nohejl
 
-this.tax <- function (gross.Income, months = 12) {
-
-  socialInsuranceBase  	  <- min(gross.Income, (108024) * months)
-  employerHealthInsurance <- 0.09 * gross.Income
-  employerSocialInsurance <- 0.25 * socialInsuranceBase
+this.tax <- function <- function (gross.Income) {
+  # Checked vs. http://www.penize.cz/kalkulacky/mzdova-kalkulacka for year 2016
+  
+  YEAR_MONTHS	 <- 12
+  gross.Income.monthly	    <- gross.Income/YEAR_MONTHS
+  fourTimesAvgWage	        <- 108024
+  solidarityTreshold	        <- fourTimesAvgWage*YEAR_MONTHS
+  socialInsuranceTreshold   <- solidarityTreshold			# "happens" to be the same
+  socialInsuranceMonths     <- max(ceiling(socialInsuranceTreshold/gross.Income.monthly),YEAR_MONTHS)
+  socialInsuranceBase  	    <- gross.Income.monthly*YEAR_MONTHS
+  employerHealthInsurance   <- 0.09 * gross.Income
+  employerSocialInsurance   <- 0.25 * socialInsuranceBase
   supergross <- gross.Income + employerHealthInsurance + employerSocialInsurance
   
-  generalDeduction	<- (2070) * months
+  generalDeduction	<- 2070*YEAR_MONTHS
   incomeTax			<- max( 0, 0.15 * supergross - generalDeduction)
   
-  healthInsurance 	<- 0.045 * supergross
+  healthInsurance 	<- 0.045 * gross.Income
   socialInsurance 	<- 0.065 * socialInsuranceBase
-  solidarityBracket <- (108024) * months
-  if( gross.Income > solidarityBracket)
-  	incomeTax <- incomeTax + 0.07 * (gross.Income - solidarityBracket)
+  solidarityTax     <- 0.07 * max(0 , gross.Income - solidarityTreshold)
 
-  net.Income = gross.Income - incomeTax - healthInsurance - socialInsurance
+  net.Income = gross.Income - incomeTax - healthInsurance - socialInsurance - solidarityTax
   
   return(net.Income)
 }


### PR DESCRIPTION
Checked a few web tax calculators, corrected health insurance
caluculation (incorrectly calculated fom supergross), and social
security calculation for high incomes. Restricted the calculation to a
fiscal year (in order to effectively apply social sercurity ceiling).
